### PR TITLE
fix: logs folder renamed to reports

### DIFF
--- a/src/components/pegase/navbar/Navbar.tsx
+++ b/src/components/pegase/navbar/Navbar.tsx
@@ -37,11 +37,14 @@ const Navbar = ({ id, topItems, bottomItems }: StdNavbarProps) => {
         version={`v${import.meta.env.VITE_APP_VERSION}`}
         expanded={expanded}
       />
+
       <StdNavbarMenu menuItems={topItems} expanded={expanded} />
-      <StdDivider extraClasses="mt-auto" />
-      <StdNavbarMenu menuItems={bottomItems} expanded={expanded} />
-      <StdDivider />
-      <StdNavbarController action={toggleExpanded} id={controllerId} label={controllerLabel} expanded={expanded} />
+
+      <div className="mt-auto">
+        <StdNavbarMenu menuItems={bottomItems} expanded={expanded} />
+        <StdDivider />
+        <StdNavbarController action={toggleExpanded} id={controllerId} label={controllerLabel} expanded={expanded} />
+      </div>
     </nav>
   );
 };

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -20,7 +20,7 @@ const resources = {
 
 await i18n.use(initReactI18next).init({
   resources,
-  lng: 'fr',
+  lng: 'en',
   interpolation: {
     escapeValue: false,
   },

--- a/src/pages/pegase/reports/LogsPage.tsx
+++ b/src/pages/pegase/reports/LogsPage.tsx
@@ -1,0 +1,9 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+export const LogsPage = () => <div>LogsPage</div>;
+
+export default LogsPage;

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -12,7 +12,7 @@ import { StdIconId } from './shared/utils/common/mappings/iconMaps';
 const Settings = lazy(() => import('./pages/pegase/settings/Settings'));
 const HomePage = lazy(() => import('./pages/pegase/home/HomePage'));
 const ProjectsPage = lazy(() => import('./pages/pegase/projects/Projects'));
-const LogsPage = lazy(() => import('./pages/pegase/logs/Logs'));
+const LogsPage = lazy(() => import('./pages/pegase/reports/LogsPage'));
 const AntaresPage = lazy(() => import('./pages/pegase/antares/Antares'));
 const LogoutPage = lazy(() => import('./pages/pegase/logout/Logout'));
 
@@ -38,7 +38,7 @@ export const menuTopData: MenuNavItem[] = [
     key: 'logs',
     label: 'page.@logs',
     path: '/logs',
-    icon: StdIconId.Settings,
+    icon: StdIconId.ReceiptLong,
     component: LogsPage,
   },
   {

--- a/src/shared/i18n/en.json
+++ b/src/shared/i18n/en.json
@@ -1,8 +1,8 @@
 {
   "components": {
     "navbar": {
-      "@expand": "Agrandir le menu",
-      "@minimize": "Minimize menu"
+      "@expand": "Maximize",
+      "@minimize": "Minimize"
     },
     "popover": {
       "@close": "Close"


### PR DESCRIPTION
Logs folder renamed to reports as logs is key word in .gitignore