### PR TITLE
fix: ANT-2613 - Buttons "generate a study" and "pagination" should be visible

### DIFF
--- a/src/pages/pegase/home/components/StudyTableHeaders.tsx
+++ b/src/pages/pegase/home/components/StudyTableHeaders.tsx
@@ -44,7 +44,7 @@ const getStudyTableHeaders = () => {
     columnHelper.accessor('createdBy', {
       header: t('home.@user_name'),
       cell: ({ getValue }) => (
-        <StdAvatar size="s" backgroundColor="gray" fullname={getValue()} initials={getValue().substring(0, 2)} />
+        <StdAvatar size="es" backgroundColor="gray" fullname={getValue()} initials={getValue().substring(0, 2)} />
       ),
     }),
 


### PR DESCRIPTION
Utiliser la valeur de size indiquée dans les maquettes pour la taille de l'avatar afin que les lignes du tableau soient moins importantes.