### PR TITLE
Feat: ANT-3854 - Fecth and import params modulation

### DIFF
--- a/src/gitInfo.ts
+++ b/src/gitInfo.ts
@@ -1,5 +1,5 @@
 export const GIT_INFO = {
-  branch: "feat/ANT-ANT-3976_thermal_handle_study_generated",
-  commit: "762bd758",
-  commitTime: "2025-10-09T08:35:42.457Z"
+  branch: "feat/ANT-3854_importParamsModulation",
+  commit: "88573980",
+  commitTime: "2025-10-13T14:07:45.655Z"
 };

--- a/src/mocks/data/tests/trajectory.mock.ts
+++ b/src/mocks/data/tests/trajectory.mock.ts
@@ -335,6 +335,24 @@ export const mockFsTrajectoryThermalCapacityArray: FsTrajectory[] = [
   },
 ];
 
+export const mockFsTrajectoryParaModulationArray: FsTrajectory[] = [
+  {
+    trajectoryName: 'params',
+    type: TRAJECTORY_TYPE.THERMAL_TECHNICAL_MODULATION_PARAMETER,
+    lastModifiedDate: '2025-07-02T11:57:48.493018687' as unknown as Date,
+  },
+  {
+    trajectoryName: 'params_2',
+    type: TRAJECTORY_TYPE.THERMAL_TECHNICAL_MODULATION_PARAMETER,
+    lastModifiedDate: '2025-07-02T11:57:48.493018687' as unknown as Date,
+  },
+  {
+    trajectoryName: 'params_PEMMDB',
+    type: TRAJECTORY_TYPE.THERMAL_TECHNICAL_MODULATION_PARAMETER,
+    lastModifiedDate: '2025-06-27T10:40:47.410233' as unknown as Date,
+  },
+];
+
 export const mockTrajectoryAreaData: TrajectoryAreaData[] = [
   {
     areaName: 'CH',

--- a/src/shared/const/apiEndPoint.ts
+++ b/src/shared/const/apiEndPoint.ts
@@ -37,6 +37,7 @@ export const TRAJECTORY_UNLINK_ALL_TO_STUDY_ENDPOINT = `${BASE_URL}/v1/trajector
 export const TRAJECTORY_THERMAL_INSTALLED_POWER_IMPORT = `${BASE_URL}/v1/trajectory/thermal-capacity`;
 export const TRAJECTORY_THERMAL_COMMON_PARAMETER_IMPORT = `${BASE_URL}/v1/trajectory/thermal-common-parameter`;
 export const TRAJECTORY_THERMAL_SPECIFIC_PARAMETER_IMPORT = `${BASE_URL}/v1/trajectory/thermal-specific-parameter`;
+export const TRAJECTORY_THERMAL_MODULATION_PARAMETER_IMPORT = `${BASE_URL}/v1/trajectory/thermal-modulation-parameter`;
 
 //ABOUT
 export const ACTUATOR_ENDPOINT = `${BASE_URL}/actuator/info`;

--- a/src/shared/services/test/trajectoryService.test.tsx
+++ b/src/shared/services/test/trajectoryService.test.tsx
@@ -559,10 +559,10 @@ describe('uploadTrajectory', () => {
     });
   });
 
-  it('should import THERMAL_TECHNICAL_SPECIFIC_PARAMETER trajectory into data base', async () => {
+  it('should import TRAJECTORY_THERMAL_MODULATION_PARAMETER_IMPORT trajectory into data base', async () => {
     await uploadTrajectory(
-      TRAJECTORY_TYPE.THERMAL_TECHNICAL_SPECIFIC_PARAMETER,
-      'specific_param_BP_23',
+      TRAJECTORY_TYPE.THERMAL_TECHNICAL_MODULATION_PARAMETER,
+      'param',
       '2030-2031',
       25,
       'Specific',
@@ -574,7 +574,7 @@ describe('uploadTrajectory', () => {
     await waitFor(() => {
       expect(progressService.fetchWithProgress).toHaveBeenCalledTimes(1);
       expect(progressService.fetchWithProgress).toHaveBeenCalledWith(
-        `https://mockapi.com/v1/trajectory/thermal-specific-parameter?area=FR&trajectoryToUse=specific_param_BP_23&horizon=2030-2031&studyId=25`,
+        `https://mockapi.com/v1/trajectory/thermal-modulation-parameter?area=FR&trajectoryToUse=param&horizon=2030-2031&studyId=25`,
         requestOptions,
         onProgress,
       );

--- a/src/shared/services/trajectoryService.ts
+++ b/src/shared/services/trajectoryService.ts
@@ -15,6 +15,7 @@ import {
   TRAJECTORY_THERMAL_COMMON_PARAMETER_IMPORT,
   TRAJECTORY_THERMAL_INSTALLED_POWER_IMPORT,
   TRAJECTORY_THERMAL_SPECIFIC_PARAMETER_IMPORT,
+  TRAJECTORY_THERMAL_MODULATION_PARAMETER_IMPORT,
   TRAJECTORY_UNLINK_ALL_TO_STUDY_ENDPOINT,
   TRAJECTORY_UNLINK_MULTIPLE_TO_STUDY_ENDPOINT,
   TRAJECTORY_UNLINK_TO_STUDY_ENDPOINT,
@@ -128,7 +129,10 @@ export const uploadTrajectory = async (
     urlApi = `${TRAJECTORY_THERMAL_COMMON_PARAMETER_IMPORT}?trajectoryToUse=${trajectoryName}&horizon=${horizon}&studyId=${studyId}`;
   } else if (trajectoryType === TRAJECTORY_TYPE.THERMAL_TECHNICAL_SPECIFIC_PARAMETER) {
     urlApi = `${TRAJECTORY_THERMAL_SPECIFIC_PARAMETER_IMPORT}?area=${subArea ?? ''}&trajectoryToUse=${trajectoryName}&horizon=${horizon}&studyId=${studyId}`;
-  } else {
+  } else if (trajectoryType === TRAJECTORY_TYPE.THERMAL_TECHNICAL_MODULATION_PARAMETER) {
+  urlApi = `${TRAJECTORY_THERMAL_MODULATION_PARAMETER_IMPORT}?area=${subArea ?? ''}&trajectoryToUse=${trajectoryName}&horizon=${horizon}&studyId=${studyId}`;
+  }
+    else {
     urlApi = `${TRAJECTORY_ENDPOINT}?trajectoryType=${trajectoryType}&trajectoryToUse=${trajectoryName}&horizon=${horizon}&studyId=${studyId}`;
   }
 

--- a/src/shared/utils/formFormatter.ts
+++ b/src/shared/utils/formFormatter.ts
@@ -13,11 +13,14 @@ export const convertToSelectionOptionType = (trajectories: DbTrajectory[]): Sele
     label: trajectory.trajectoryName,
   }));
 
+export const isRepositoryTrajectory = (type: TRAJECTORY_TYPE) =>
+  type === TRAJECTORY_TYPE.LOAD || type === TRAJECTORY_TYPE.THERMAL_TECHNICAL_MODULATION_PARAMETER;
+
 export const convertToFSSelectionOptionType = (options: FsTrajectory[]): SelectOption[] =>
   options.map((option, indexTrajectory) => ({
     id: indexTrajectory,
     label:
-      option.trajectoryName && option.type !== TRAJECTORY_TYPE.LOAD
+      option.trajectoryName && !isRepositoryTrajectory(option.type)
         ? option.trajectoryName.substring(0, option.trajectoryName.lastIndexOf('.'))
         : option.trajectoryName,
   }));

--- a/src/shared/utils/test/formFormatter.test.ts
+++ b/src/shared/utils/test/formFormatter.test.ts
@@ -1,9 +1,15 @@
-import { convertToFSSelectionOptionType, convertToSelectionOptionType } from '@/shared/utils/formFormatter.ts';
+import {
+  convertToFSSelectionOptionType,
+  convertToSelectionOptionType,
+  isRepositoryTrajectory,
+} from '@/shared/utils/formFormatter.ts';
 import {
   mockDbTrajectoryArray,
   mockFsTrajectoryAreaArray,
   mockFsTrajectoryLoadArray,
+  mockFsTrajectoryParaModulationArray,
 } from '@/mocks/data/tests/trajectory.mock.ts';
+import { TRAJECTORY_TYPE } from '@/shared/enum/trajectory.ts';
 
 describe('convertToSelectionOptionType', () => {
   it('should return an array of SelectOption type when array of DbTrajectory as an argument', () => {
@@ -33,7 +39,29 @@ describe('convertToFSSelectionOptionType', () => {
       { id: 3, label: 'BP23_AREF_EU_CBN_VIDE' },
     ]);
   });
+  it('should return an array of SelectOption type in which label is the trajectory name when array of THERMAL_TECHNICAL_MODULATION_PARAMETER as an argument', () => {
+    expect(convertToFSSelectionOptionType(mockFsTrajectoryParaModulationArray)).toEqual([
+      { id: 0, label: 'params' },
+      { id: 1, label: 'params_2' },
+      { id: 2, label: 'params_PEMMDB' },
+    ]);
+  });
   it('should return an empty array when empty array as an argument', () => {
     expect(convertToSelectionOptionType([])).toEqual([]);
+  });
+});
+
+describe('isRepositoryTrajectory', () => {
+  it('should return false for TRAJECTORY_TYPE AREA', () => {
+    expect(isRepositoryTrajectory(TRAJECTORY_TYPE.AREA)).toBeFalsy();
+  });
+  it('should return false for TRAJECTORY_TYPE LINK', () => {
+    expect(isRepositoryTrajectory(TRAJECTORY_TYPE.LINK)).toBeFalsy();
+  });
+  it('should return true for TRAJECTORY_TYPE LOAD', () => {
+    expect(isRepositoryTrajectory(TRAJECTORY_TYPE.LOAD)).toBeTruthy();
+  });
+  it('should return false for TRAJECTORY_TYPE THERMAL_TECHNICAL_MODULATION_PARAMETER', () => {
+    expect(isRepositoryTrajectory(TRAJECTORY_TYPE.THERMAL_TECHNICAL_MODULATION_PARAMETER)).toBeTruthy();
   });
 });


### PR DESCRIPTION
Récupération des trajectoires THERMAL_TECHNICAL_MODULATION_PARAMETER depuis le file system : 
https://gopro-tickets.rte-france.com/browse/ANT-3831
Import de trajectoire THERMAL_TECHNICAL_MODULATION_PARAMETER en BDD :
https://gopro-tickets.rte-france.com/browse/ANT-3854
Récupération des trajectoires THERMAL_TECHNICAL_MODULATION_PARAMETER depuis la BDD et création de lien entre l'étude et la trajectoire :
https://gopro-tickets.rte-france.com/browse/ANT-3863